### PR TITLE
Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+dist
+build
+*.egg-info

--- a/cmq/account.py
+++ b/cmq/account.py
@@ -27,9 +27,12 @@ class Account:
         self.secretId = secretId
         self.secretKey = secretKey
         self.debug = debug
-        self.logger = CMQLogger.get_logger()
+        if debug:
+            self.logger = CMQLogger.get_logger()
+        else:
+            self.logger = CMQLogger.get_stream_logger()
         self.cmq_client = CMQClient(host, secretId, secretKey, logger=self.logger)
-        
+
     def set_sign(self, sign='sha256'):
         '''
           @fucntion set_sign : set sign method 

--- a/cmq/cmq_tool.py
+++ b/cmq/cmq_tool.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-
-import sys
-import string
-import types
+import os
 import logging
 import logging.handlers
 from cmq.cmq_exception import *
@@ -14,10 +11,18 @@ PERMISSION_ACTIONS = ["setqueueattributes", "getqueueattributes", "sendmessage",
 
 class CMQLogger:
     @staticmethod
+    def get_stream_logger(log_name="CMQ_python_sdk", log_level=logging.INFO):
+        logger = logging.getLogger(log_name)
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(log_level)
+        return logger
+
+    @staticmethod
     def get_logger(log_name="CMQ_python_sdk", log_file="CMQ_python_sdk.log", log_level=logging.INFO):
         logger = logging.getLogger(log_name)
         if logger.handlers == []:
-            fileHandler = logging.handlers.RotatingFileHandler(log_file, maxBytes=10*1024*1024)
+            base_path = os.path.split(os.path.abspath(__file__))[0]
+            fileHandler = logging.handlers.RotatingFileHandler(os.path.join(base_path, log_file), maxBytes=10*1024*1024)
             formatter = logging.Formatter('[%(asctime)s] [%(name)s] [%(levelname)s] [%(filename)s:%(lineno)d] [%(thread)d] %(message)s', '%Y-%m-%d %H:%M:%S')
             fileHandler.setFormatter(formatter)
             logger.addHandler(fileHandler)

--- a/cmq/cmq_tool.py
+++ b/cmq/cmq_tool.py
@@ -21,8 +21,7 @@ class CMQLogger:
     def get_logger(log_name="CMQ_python_sdk", log_file="CMQ_python_sdk.log", log_level=logging.INFO):
         logger = logging.getLogger(log_name)
         if logger.handlers == []:
-            base_path = os.path.split(os.path.abspath(__file__))[0]
-            fileHandler = logging.handlers.RotatingFileHandler(os.path.join(base_path, log_file), maxBytes=10*1024*1024)
+            fileHandler = logging.handlers.RotatingFileHandler(log_file, maxBytes=10*1024*1024)
             formatter = logging.Formatter('[%(asctime)s] [%(name)s] [%(levelname)s] [%(filename)s:%(lineno)d] [%(thread)d] %(message)s', '%Y-%m-%d %H:%M:%S')
             fileHandler.setFormatter(formatter)
             logger.addHandler(fileHandler)

--- a/cmq/cmq_tool.py
+++ b/cmq/cmq_tool.py
@@ -1,10 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-
-import sys
-import string
-import types
+import os
 import logging
 import logging.handlers
 from cmq.cmq_exception import *
@@ -13,6 +10,13 @@ METHODS = ["POST", "GET"]
 PERMISSION_ACTIONS = ["setqueueattributes", "getqueueattributes", "sendmessage", "receivemessage", "deletemessage", "peekmessage", "changevisibility"]
 
 class CMQLogger:
+    @staticmethod
+    def get_stream_logger(log_name="CMQ_python_sdk", log_level=logging.INFO):
+        logger = logging.getLogger(log_name)
+        logger.addHandler(logging.StreamHandler())
+        logger.setLevel(log_level)
+        return logger
+
     @staticmethod
     def get_logger(log_name="CMQ_python_sdk", log_file="CMQ_python_sdk.log", log_level=logging.INFO):
         logger = logging.getLogger(log_name)


### PR DESCRIPTION
避免RotatingFileHandler自动创建log文件
这一行为将会遇到权限问题和并发风险
权限问题来自于程序没有定义在某个确定的目录下生成log，当它以modules安装时，会将日志输出至安装目录
并发风险来自于，多进程状态下，多个logger可能将同时向一个文件写入，这可能是有风险的
参考文档：https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
因此添加部分代码，控制在非debug环境中不向文件输出日志（不创建日志文件）